### PR TITLE
makefiles: set up for multi os.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 script:
-- if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then ./util/continuous-build.sh; fi
+- make travis
 compiler:
 - gcc-4.8
 env:
@@ -8,6 +8,7 @@ env:
   - secure: tARd2A5pHaoxooEXFhjnbLcPCp5cKPZTH4f+tMajMrSAkSmuNpL+GxUsa3wGhTRm0S3LOHtstqB0w8aRkdmwoytj64D9idX6121Ui9NuA47YL+NFRs76Oh3JcEzvdTu2ZhfTlvOwpDR1zjXhBBSVhFB8Tr2+N9Ywz95SjIgybx8V8B6jk946lPMK5dm1MBJ9iKy9Xngv49DNy5A3g7nalzK3+gL8yeKLdgu10KqZkLFXcdxoU2Nq5A/T8mrufxEe7tYmmGRpN9YqXn4rRnKg3BrEPXWcYfD8nkyUeaCRXIx9autWpGFU8HmxvWvOKrcDR6FjzrD7uWSlVGh9WGoomwSCgRb9pJSYOnORGrlTUkO/badEZHXBCAlCV6RgL2CFENxr55p2Ddb+iXxTM+iP5sJ1bhVQVbIL590lNqMkxvhT46g+meE6xIil+05OC5PR2B/SqhQ0jqcvjKRsK232KobseKQ1h7+jm2kZMfl45nPq1q+dlsN1IvKKN5XgyIhAje1eudvAeBzFbl0I7k0ZUnikKGW0AB1pjTDcFLIQFuzTZOix1uYrahI25oo1FgE1iLCbhgXQKtAW++sgxdb31fX7Rzi+YZCBprJ8PbJ4vUiUIhKfb5ORT71cmew7GVlFmKclVgDMaNOeGiJjUsHgPXx0sDsHsGT4RLwvxzpg+Cw=
   - ARCH=amd64
   - HARVEY=$TRAVIS_BUILD_DIR
+  - OS=linux
   matrix:
 addons:
   apt:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-include Makefile.inc
+include $(OS).inc
 
 DIRS=lib
 

--- a/linux.inc
+++ b/linux.inc
@@ -9,9 +9,9 @@ ARCH=amd64
 
 BIN=${HARVEY}/${ARCH}/bin
 LIB=${HARVEY}/${ARCH}/lib
-AS=x86_64-harvey-elf-as
-CC=x86_64-harvey-elf-gcc
-LD=x86_64-harvey-elf-ld
+AS=as
+CC=gcc
+LD=ld
 
 IDIR=${HARVEY}/include
 IOBJDIR=${HARVEY}/${ARCH}/include
@@ -20,5 +20,5 @@ CFLAGS= -std=c99 -O0 -static -mno-red-zone -ffreestanding -nostdinc -D_SUSV2_SOU
 
 WFLAGS=-Wall -Wno-missing-braces -Wno-parentheses -Wno-unknown-pragmas -Wuninitialized -Wmaybe-uninitialized 
 
-AR=x86_64-harvey-elf-ar				# manipulating libraries
+AR=ar				# manipulating libraries
 RANLIB=echo			# for updating libraries


### PR DESCRIPTION
mv Makefile.inc to linux.inc

Makefile includes $(OS).inc

So users must set OS to something, and we get the right defines.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>