### PR TITLE
Remove ../.. in Makefiles

### DIFF
--- a/cmd/pdksh/Makefile
+++ b/cmd/pdksh/Makefile
@@ -1,4 +1,4 @@
-include ../../$(OS).inc
+include $(APEX)/$(OS).inc
 
 TARGET = pdksh
 SRCS = $(wildcard *.c)

--- a/lib/ap/amd64/Makefile
+++ b/lib/ap/amd64/Makefile
@@ -1,4 +1,4 @@
-include ../../../$(OS).inc
+include $(APEX)/$(OS).inc
 
 TARGET = libap.a
 SRCS =\

--- a/lib/ap/crt/Makefile
+++ b/lib/ap/crt/Makefile
@@ -1,4 +1,4 @@
-include ../../../$(OS).inc
+include $(APEX)/$(OS).inc
 
 CFLAGS += -I../internal
 CP = cp

--- a/lib/ap/gen/Makefile
+++ b/lib/ap/gen/Makefile
@@ -1,4 +1,4 @@
-include ../../../$(OS).inc
+include $(APEX)/$(OS).inc
 
 TARGET = libap.a
 SRCS = $(wildcard *.c)

--- a/lib/ap/locale/Makefile
+++ b/lib/ap/locale/Makefile
@@ -1,4 +1,4 @@
-include ../../../$(OS).inc
+include $(APEX)/$(OS).inc
 
 TARGET = libap.a
 SRCS = $(wildcard *.c)

--- a/lib/ap/math/Makefile
+++ b/lib/ap/math/Makefile
@@ -1,4 +1,4 @@
-include ../../../$(OS).inc
+include $(APEX)/$(OS).inc
 
 TARGET = libap.a
 SRCS = $(wildcard *.c)

--- a/lib/ap/multibyte/Makefile
+++ b/lib/ap/multibyte/Makefile
@@ -1,4 +1,4 @@
-include ../../../$(OS).inc
+include $(APEX)/$(OS).inc
 
 TARGET = libap.a
 SRCS = $(wildcard *.c)

--- a/lib/ap/plan9/Makefile
+++ b/lib/ap/plan9/Makefile
@@ -1,4 +1,4 @@
-include ../../../$(OS).inc
+include $(APEX)/$(OS).inc
 
 TARGET = libap.a
 SRCS = $(wildcard *.c)

--- a/lib/ap/posix/Makefile
+++ b/lib/ap/posix/Makefile
@@ -1,4 +1,4 @@
-include ../../../$(OS).inc
+include $(APEX)/$(OS).inc
 
 TARGET = libap.a
 SRCS = $(wildcard *.c)

--- a/lib/ap/stdio/Makefile
+++ b/lib/ap/stdio/Makefile
@@ -1,4 +1,4 @@
-include ../../../$(OS).inc
+include $(APEX)/$(OS).inc
 
 TARGET = libap.a
 SRCS = $(wildcard *.c)

--- a/lib/ap/stdlib/Makefile
+++ b/lib/ap/stdlib/Makefile
@@ -1,4 +1,4 @@
-include ../../../$(OS).inc
+include $(APEX)/$(OS).inc
 
 TARGET = libap.a
 SRCS = $(wildcard *.c)

--- a/lib/ap/string/Makefile
+++ b/lib/ap/string/Makefile
@@ -1,4 +1,4 @@
-include ../../../$(OS).inc
+include $(APEX)/$(OS).inc
 
 TARGET = libap.a
 SRCS = $(wildcard *.c)

--- a/lib/bsd/Makefile
+++ b/lib/bsd/Makefile
@@ -1,4 +1,4 @@
-include ../../$(OS).inc
+include $(APEX)/$(OS).inc
 
 TARGET = libbsd.a
 SRCS = $(wildcard *.c)


### PR DESCRIPTION
This won't be needed on harvey (that's what bind -a is for)
and it's ugly on Linux.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>