### PR TITLE
hack: stub out sbrk

### DIFF
--- a/cmd/pdksh/alloc.C
+++ b/cmd/pdksh/alloc.C
@@ -14,7 +14,7 @@
 #include "sh.h"
 
 
-
+#define DEBUG_ALLOC 1
 # if DEBUG_ALLOC
 void acheck ARGS((Area *ap));
 #  define ACHECK(ap)	acheck(ap)
@@ -61,7 +61,7 @@ static void *asplit ARGS((Area *ap, Block *bp, Cell *fp, Cell *fpp, int cells));
 
 /* create empty Area */
 Area *
-ainit( register Area *ap)
+ainit(  Area *ap)
 {
 	ap->freelist = &aempty;
 	ACHECK(ap);
@@ -70,10 +70,10 @@ ainit( register Area *ap)
 
 /* free all object in Area */
 void
-afreeall( register Area *ap)
+afreeall(  Area *ap)
 {
-	register Block *bp;
-	register Block *tmp;
+	 Block *bp;
+	 Block *tmp;
 
 	ACHECK(ap);
 	bp = ap->freelist;
@@ -90,12 +90,11 @@ afreeall( register Area *ap)
 
 /* allocate object from Area */
 void *
-alloc( size_t size, register Area *ap)
+alloc( size_t size,  Area *ap)
 {
 	int cells, acells;
 	Block *bp = 0;
 	Cell *fp = 0, *fpp = 0;
-
 	ACHECK(ap);
 	if (size <= 0)
 		aerror(ap, "allocate bad size");
@@ -156,12 +155,7 @@ alloc( size_t size, register Area *ap)
  * objects.  Returns the `allocated' object.
  */
 static void *
-asplit(ap, bp, fp, fpp, cells)
-	Area *ap;
-	Block *bp;
-	Cell *fp;
-	Cell *fpp;
-	int cells;
+asplit( Area *ap, Block *bp, Cell *fp, Cell *fpp, int cells)
 {
 	Cell *dp = fp;	/* allocated object */
 	int split = (fp-1)->size - cells;
@@ -190,10 +184,7 @@ asplit(ap, bp, fp, fpp, cells)
 
 /* change size of object -- like realloc */
 void *
-aresize(ptr, size, ap)
-	register void *ptr;
-	size_t size;
-	Area *ap;
+aresize(  void *ptr, size_t size, Area *ap)
 {
 	int cells;
 	Cell *dp = (Cell*) ptr;
@@ -328,11 +319,11 @@ aresize(ptr, size, ap)
 void
 afree(ptr, ap)
 	void *ptr;
-	register Area *ap;
+	 Area *ap;
 {
-	register Block *bp;
-	register Cell *fp, *fpp;
-	register Cell *dp = (Cell*)ptr;
+	 Block *bp;
+	 Cell *fp, *fpp;
+	 Cell *dp = (Cell*)ptr;
 
 	ACHECK(ap);
 	if (ptr == 0)
@@ -386,9 +377,7 @@ afree(ptr, ap)
 }
 
 static void
-ablockfree(bp, ap)
-	Block *bp;
-	Area *ap;
+ablockfree( Block *bp, Area *ap)
 {
 	/* NOTE: If this code changes, similar changes may be
 	 * needed in alloc() (where realloc fails).
@@ -407,8 +396,7 @@ ablockfree(bp, ap)
 
 # if DEBUG_ALLOC
 void
-acheck(ap)
-	Area *ap;
+acheck( Area *ap)
 {
 	Block *bp, *bpp;
 	Cell *dp, *dptmp, *fp;
@@ -443,7 +431,8 @@ acheck(ap)
 		fp = bp->freelist;
 		for (dp = &bp->cell[NOBJECT_FIELDS]; dp != bp->last; ) {
 			if ((dp-2)->block != bp) {
-				shellf("acheck: fragment's block is wrong\n");
+				printf("CHECK gp %p \n", bp);
+				shellf("acheck: fragment's block is wrong: want %p, got %p\n", bp, (dp-2)->block);
 				ok = 0;
 			}
 			isfree = dp == fp;
@@ -504,10 +493,7 @@ acheck(ap)
 }
 
 void
-aprint(ap, ptr, size)
-	register Area *ap;
-	void *ptr;
-	size_t size;
+aprint( Area *ap, void *ptr, size_t size)
 {
 	Block *bp;
 

--- a/cmd/pdksh/alloc.c
+++ b/cmd/pdksh/alloc.c
@@ -41,6 +41,7 @@ union Cell {
 	size_t	size;
 	Cell   *next;
 	Block  *block;
+#warning "chck this alignment"
 	struct {int _;} junk;	/* alignment */
 	double djunk;		/* alignment */
 };
@@ -60,8 +61,7 @@ static void *asplit ARGS((Area *ap, Block *bp, Cell *fp, Cell *fpp, int cells));
 
 /* create empty Area */
 Area *
-ainit(ap)
-	register Area *ap;
+ainit( register Area *ap)
 {
 	ap->freelist = &aempty;
 	ACHECK(ap);
@@ -70,8 +70,7 @@ ainit(ap)
 
 /* free all object in Area */
 void
-afreeall(ap)
-	register Area *ap;
+afreeall( register Area *ap)
 {
 	register Block *bp;
 	register Block *tmp;
@@ -91,9 +90,7 @@ afreeall(ap)
 
 /* allocate object from Area */
 void *
-alloc(size, ap)
-	size_t size;
-	register Area *ap;
+alloc( size_t size, register Area *ap)
 {
 	int cells, acells;
 	Block *bp = 0;

--- a/cmd/pdksh/main.c
+++ b/cmd/pdksh/main.c
@@ -92,6 +92,7 @@ main(argc, argv)
 	int argc;
 	register char **argv;
 {
+void acheck(Area *p);
 	register int i;
 	int argi;
 	Source *s;
@@ -124,6 +125,7 @@ main(argc, argv)
 
 	ainit(&aperm);		/* initialize permanent Area */
 
+acheck(&aperm);
 	/* set up base enviroment */
 	memset(&env, 0, sizeof(env));
 	env.type = E_NONE;
@@ -133,33 +135,45 @@ main(argc, argv)
 
 	/* Do this first so output routines (eg, errorf, shellf) can work */
 	initio();
+acheck(&aperm);
 
 	initvar();
+acheck(&aperm);
 
 	initctypes();
+acheck(&aperm);
 
 	inittraps();
-
+acheck(&aperm);
+{ void *p = alloc(128, APERM); afree(p, APERM); }
 #ifdef KSH
 	coproc_init();
 #endif /* KSH */
 
 	/* set up variable and command dictionaries */
 	tinit(&taliases, APERM, 0);
+acheck(&aperm);
 	tinit(&aliases, APERM, 0);
+acheck(&aperm);
 	tinit(&homedirs, APERM, 0);
+acheck(&aperm);
 
 	/* define shell keywords */
 	initkeywords();
 
+acheck(&aperm);
 	/* define built-in commands */
 	tinit(&builtins, APERM, 64); /* must be 2^n (currently 40 builtins) */
+acheck(&aperm);
 	for (i = 0; shbuiltins[i].name != NULL; i++)
 		builtin(shbuiltins[i].name, shbuiltins[i].func);
+acheck(&aperm);
 	for (i = 0; kshbuiltins[i].name != NULL; i++)
 		builtin(kshbuiltins[i].name, kshbuiltins[i].func);
+acheck(&aperm);
 
 	init_histvec();
+acheck(&aperm);
 
 	def_path = DEFAULT__PATH;
 #if defined(HAVE_CONFSTR) && defined(_CS_PATH)
@@ -542,6 +556,7 @@ shell(s, toplevel)
 	volatile int interactive = Flag(FTALKING) && toplevel;
 	int i;
 
+open("SHELL!", 0);
 	newenv(E_PARSE);
 	if (interactive)
 		really_exit = 0;

--- a/cmd/pdksh/noalloc.c
+++ b/cmd/pdksh/noalloc.c
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+/*
+ * area-based allocation built on malloc/free
+ */
+
+#include "sh.h"
+
+
+/* create empty Area */
+Area *
+ainit(  Area *ap)
+{
+	return ap;
+}
+
+/* free all object in Area */
+void
+afreeall(  Area *ap)
+{
+}
+
+/* allocate object from Area */
+void *
+alloc( size_t size,  Area *ap)
+{
+	return malloc(size);
+}
+
+/* change size of object -- like realloc */
+void *
+aresize(  void *ptr, size_t size, Area *ap)
+{
+	return realloc(ptr, size);
+}
+
+void
+afree( void *ptr, Area *ap)
+{
+	free(ptr);
+}
+
+void
+acheck( Area *ap)
+{
+}
+
+void
+aprint( Area *ap, void *ptr, size_t size)
+{
+}

--- a/cmd/pdksh/sh.h
+++ b/cmd/pdksh/sh.h
@@ -15,12 +15,7 @@
 
 #include "config.h"	/* system and option configuration info */
 
-#ifdef HAVE_PROTOTYPES
 # define	ARGS(args)	args	/* prototype declaration */
-#else
-# define	ARGS(args)	()	/* K&R declaration */
-#endif
-
 
 /* Start of common headers */
 

--- a/include/signal.h
+++ b/include/signal.h
@@ -65,7 +65,7 @@ extern int raise(int);
 
 typedef long sigset_t;
 struct sigaction {
-	void		(*sa_handler)(void);
+	void		(*sa_handler)(int, char*, void*);
 	sigset_t	sa_mask;
 	int		sa_flags;
 };

--- a/lib/ap/gen/mbwc.c
+++ b/lib/ap/gen/mbwc.c
@@ -47,6 +47,7 @@ enum {
 	NT1BITS = 11,
 	NSHFT = 5,
 	NCSHFT = NSHFT + 1,
+	/* this is crap -- it overflows. */
 	WCHARMSK = (1<< (8*MB_LEN_MAX - 1)) - 1,
 };
 

--- a/lib/ap/plan9/_envsetup.c
+++ b/lib/ap/plan9/_envsetup.c
@@ -53,7 +53,7 @@ _envsetup(void)
 	char **pp;
 	char name[NAME_MAX+5];
 	Dir *d9, *d9a;
-
+return;
 	nohandle = 0;
 	fdinited = 0;
 	cnt = 0;

--- a/lib/ap/plan9/_envsetup.c
+++ b/lib/ap/plan9/_envsetup.c
@@ -26,7 +26,15 @@
  *
  * Also, register the note handler.
  */
-
+//#define HACK
+#ifdef HACK
+struct Dir hack[] = {
+	{.name="hi", .length=8}, 
+	{.name="there", .length=2},
+	{.name="nohandle", .length=3},
+};
+char *data[] = {"12345678", "fa", "yes"};
+#endif
 char **environ;
 int errno;
 unsigned long _clock;
@@ -61,8 +69,13 @@ _envsetup(void)
 	if(p == 0)
 		return;
 	psize = Envhunk;
+#ifdef HACK
+	nd = 3;
+	d9a = hack;
+#else
 	nd = _dirreadall(dfd, &d9a);
 	_CLOSE(dfd);
+#endif
 	for(j=0; j<nd; j++){
 		d9 = &d9a[j];
 		n = strlen(d9->name);
@@ -74,7 +87,9 @@ _envsetup(void)
 			psize += (n+m+2 < Envhunk)? Envhunk : n+m+2;
 			ps = realloc(ps, psize);
 			if (ps == 0) {
+#ifndef HACK
 				free(d9a);
+#endif
 				return;
 			}
 			p = ps + i;
@@ -82,10 +97,14 @@ _envsetup(void)
 		memcpy(p, d9->name, n);
 		p[n] = '=';
 		strcpy(name+3, d9->name);
+#ifdef HACK
+		memcpy(name, &data[i], m);
+#else
 		f = _OPEN(name, O_RDONLY);
 		if(f < 0 || read(f, p+n+1, m) != m)
 			m = 0;
 		_CLOSE(f);
+#endif
 		if(p[n+m] == 0)
 			m--;
 		for(i=0; i<m; i++)
@@ -102,7 +121,9 @@ _envsetup(void)
 		p += n+m+2;
 		cnt++;
 	}
+#ifndef HACK
 	free(d9a);
+#endif
 	if(!fdinited)
 		_fdinit(0, 0);
 	pp = malloc((1+cnt)*sizeof(char *));

--- a/lib/ap/plan9/brk.c
+++ b/lib/ap/plan9/brk.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include "sys9.h"
 
+/* this is crap because end is assumed to have one element. */
 char	end[];
 static	char	*bloc = { end };
 extern	int	brk_(void*);

--- a/lib/ap/plan9/malloc.c
+++ b/lib/ap/plan9/malloc.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include <inttypes.h>
 
-typedef unsigned int	uint;
+typedef unsigned 	long uint;
 
 enum
 {
@@ -37,15 +37,30 @@ struct Arena
 };
 static Arena arena;
 
-#define datoff		((int)((Bucket*)0)->data)
+#define datoff		((uint)((Bucket*)0)->data)
 #define nil		((void*)0)
 
+/* we can remove this HACK when we are done debugging. */
+//#define HACK
+#ifdef HACK
+static void *sbrk(unsigned long incr)
+{
+	static char arena[1048576];
+	static void *v = arena;
+	void *retval;
+
+	retval = v;
+	v += incr;
+	return retval;
+}
+#else
 extern	void	*sbrk(unsigned long);
+#endif
 
 void*
 malloc(size_t size)
 {
-	uint next;
+	uintptr_t next;
 	int pow, n;
 	Bucket *bp, *nbp;
 
@@ -104,6 +119,7 @@ void
 free(void *ptr)
 {
 	Bucket *bp, **l;
+	if (sizeof(uint) != 8) { char cp = *(char *)nil;}
 
 	if(ptr == nil)
 		return;

--- a/lib/ap/stdio/vfprintf.c
+++ b/lib/ap/stdio/vfprintf.c
@@ -211,6 +211,7 @@ vfprintf(FILE *f, const char *s, va_list args)
 			flags |= tfl;
 			s++;
 		}
+		/* this is crap. s is signed. */
 		if(ocvt[*s]) nprint += (*ocvt[*s++])(f, &arg, flags, width, precision);
 		else if(*s){
 			putc(*s++, f);

--- a/lib/bsd/gettimeofday.c
+++ b/lib/bsd/gettimeofday.c
@@ -26,11 +26,11 @@ static uint64_t order = 0x0001020304050607ULL;
 static void
 be2vlong(int64_t *to, char *f)
 {
-	char *t, *o;
+	unsigned char *t, *o;
 	int i;
 
-	t = (char*)to;
-	o = (char*)&order;
+	t = (unsigned char*)to;
+	o = (unsigned char*)&order;
 	for(i = 0; i < 8; i++)
 		t[o[i]] = f[i];
 }


### PR DESCRIPTION
This is a demo of how you can stub out sbrk to test things.

You only need to do one more thing: in envsetup, fake up some
directory entries as from a real dirreadall and then you can test your code.
The way you do that is to create a static array of the structs and instead of doing a
dirreadall just set the point to the structs (just make an array of 3 or so) and set nd to 3.

Another way? Create a program that runs on harvey that does a dirreadall of #e and then prints
the C code for the static initialized struct to a file. Then just include that static initializer
in pdksh.

Not super hard, and it lets you debug on linux with gdb, which will save you a lot of time.

Don't commit this. It's just showing how you can use gdb to debug things on Linux.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>