### PR TITLE
Various fixes

### DIFF
--- a/amd64/include/stdarg.h
+++ b/amd64/include/stdarg.h
@@ -23,12 +23,12 @@ typedef char *va_list;
 */
 
 typedef __builtin_va_list va_list;
-typedef va_list __isoc_va_list; /* wchar.h */
+typedef __builtin_va_list __isoc_va_list; /* wchar.h */
 
-#define va_start(v,l)	__builtin_va_start(v,l)
-#define va_end(v)	__builtin_va_end(v)
-#define va_arg(v,l)	__builtin_va_arg(v,l)
-#define va_copy(v,l)	__builtin_va_copy(v,l)
+#define va_start(v,l)   __builtin_va_start(v,l)
+#define va_end(v)       __builtin_va_end(v)
+#define va_arg(v,l)     __builtin_va_arg(v,l)
+#define va_copy(d,s)    __builtin_va_copy(d,s)
 
 #ifdef __cplusplus
 }

--- a/include/lock.h
+++ b/include/lock.h
@@ -14,12 +14,12 @@
 #ifndef __LOCK_H
 #define __LOCK_H
 
-#include <u.h>
+#include <stdint.h>
 
 typedef struct
 {
-	long	key;
-	long	sem;
+	int32_t	key;
+	int32_t	sem;
 } Lock;
 
 #ifdef __cplusplus

--- a/lib/ap/bsd/writev.c
+++ b/lib/ap/bsd/writev.c
@@ -1,71 +1,64 @@
 /*
- * This file is part of the UCB release of Plan 9. It is subject to the license
- * terms in the LICENSE file found in the top-level directory of this
- * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
- * part of the UCB release of Plan 9, including this file, may be copied,
- * modified, propagated, or distributed except according to the terms contained
- * in the LICENSE file.
+ * Copyright (c) 1995, 1996, 1997, 1998, 1999 Kungliga Tekniska Högskolan
+ * (Royal Institute of Technology, Stockholm, Sweden).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
  */
 
-#include <sys/types.h>
-#include <unistd.h>
+#include <stdlib.h>
 #include <string.h>
-
-/* bsd extensions */
+#include <sys/types.h>
 #include <sys/uio.h>
-#include <sys/socket.h>
-
-#include "priv.h"
+#include <errno.h>
+#include <unistd.h>
 
 ssize_t
-writev(int fd, const struct iovec *v, int ent)
+writev(int d, const struct iovec *iov, int iovcnt)
 {
-	int i, n, written;
-	char *t, *e, *f;
-	char buf[10*1024];
+    ssize_t ret;
+    size_t tot = 0;
+    int i;
+    char *buf, *p;
 
-	written = 0;
-	t = buf;
-	e = buf+sizeof(buf);
-	for(;ent ; v++, ent--){
-		n = v->iov_len;
-		f = v->iov_base;
-		while(n > 0){
-			i = e-t;
-			if(n < i){
-				memmove(t, f, n);
-				t += n;
-				break;
-			}
-			memmove(t, f, i);
-			n -= i;
-			f += i;
-			i = write(fd, buf, sizeof(buf));
-			if(i < 0){
-				if(written > 0){
-					return written;
-				}else{
-					_syserrno();
-					return -1;
-				}
-			}
-			written += i;
-			if(i != sizeof(buf)) {
-				return written;
-			}
-			t = buf;
-		}
-	}
-	i = t - buf;
-	if(i > 0){
-		n = write(fd, buf, i);
-		if(n < 0){
-			if(written == 0){
-				_syserrno();
-				return -1;
-			}
-		} else
-			written += n;
-	}
-	return written;
+    for(i = 0; i < iovcnt; ++i)
+	   tot += iov[i].iov_len;
+    buf = malloc(tot);
+    if (tot != 0 && buf == NULL) {
+    	errno = ENOMEM;
+    	return -1;
+    }
+    p = buf;
+    for (i = 0; i < iovcnt; ++i) {
+	   memcpy (p, iov[i].iov_base, iov[i].iov_len);
+	   p += iov[i].iov_len;
+    }
+    ret = write (d, buf, tot);
+    free (buf);
+    return ret;
 }

--- a/lib/ap/plan9/9iounit.c
+++ b/lib/ap/plan9/9iounit.c
@@ -62,7 +62,7 @@ _IOUNIT(int fd)
 	char buf[128], *args[10];
 
 	snprint(buf, sizeof buf, "#d/%dctl", fd);
-	cfd = open(buf, OREAD);
+	cfd = __sys_open(buf, OREAD);
 	if(cfd < 0)
 		return 0;
 	i = read(cfd, buf, sizeof buf-1);

--- a/lib/ap/plan9/_envsetup.c
+++ b/lib/ap/plan9/_envsetup.c
@@ -50,7 +50,7 @@ _envsetup(void)
 	fdinited = 0;
 	cnt = 0;
 	strcpy(name, "#e");
-	dfd = open(name, 0);
+	dfd = __sys_open(name, 0);
 	if(dfd < 0){
 		environ = malloc(sizeof(char**));
 		*environ = NULL;
@@ -82,7 +82,7 @@ _envsetup(void)
 		memcpy(p, d9->name, n);
 		p[n] = '=';
 		strcpy(name+3, d9->name);
-		f = open(name, O_RDONLY);
+		f = __sys_open(name, O_RDONLY);
 		if(f < 0 || read(f, p+n+1, m) != m)
 			m = 0;
 		close(f);

--- a/lib/ap/plan9/_fdinfo.c
+++ b/lib/ap/plan9/_fdinfo.c
@@ -47,7 +47,7 @@ readprocfdinit(void)
 	char *s, *nexts;
 
 	memset(buf, 0, sizeof buf);
-	pfd = open("#c/pid", 0);
+	pfd = __sys_open("#c/pid", 0);
 	if(pfd < 0)
 		return -1;
 	if(pread(pfd, buf, 100, 0) < 0){
@@ -59,7 +59,7 @@ readprocfdinit(void)
 	strcpy(buf, "#p/");
 	_ultoa(buf+3, pid);
 	strcat(buf, "/fd");
-	pfd = open(buf, 0);
+	pfd = __sys_open(buf, 0);
 	if(pfd < 0)
 		return -1;
 	memset(buf, 0, sizeof buf);

--- a/lib/ap/plan9/_open.c
+++ b/lib/ap/plan9/_open.c
@@ -54,6 +54,11 @@ _OPEN(const char *path, int flags, ...)
 		if(n < 0)
 			_syserrno();
 	}
+	if(n >= OPEN_MAX){
+		close(n);
+		errno = ENFILE;
+		return -1;
+	}
 	if(n >= 0){
 		fi = &_fdinfo[n];
 		fi->flags = FD_ISOPEN;

--- a/lib/ap/plan9/getcwd.c
+++ b/lib/ap/plan9/getcwd.c
@@ -22,7 +22,7 @@ getcwd(char *buf, size_t len)
 {
 	int fd;
 
-	fd = open(".", OREAD);
+	fd = __sys_open(".", OREAD);
 	if(fd < 0) {
 		errno = EACCES;
 		return 0;

--- a/lib/ap/plan9/getpid.c
+++ b/lib/ap/plan9/getpid.c
@@ -20,7 +20,7 @@ getpid(void)
 	int n, f;
 	char pidbuf[15];
 
-	f = open("#c/pid", 0);
+	f = __sys_open("#c/pid", 0);
 	n = read(f, pidbuf, sizeof pidbuf);
 	if(n < 0)
 		_syserrno();

--- a/lib/ap/plan9/malloc.c
+++ b/lib/ap/plan9/malloc.c
@@ -72,7 +72,7 @@ good:
 	if(pow < CUTOFF) {
 		n = (CUTOFF-pow)+2;
 		bp = sbrk(size*n);
-		if((intptr_t)bp == -1)
+		if((intptr_t)bp < 0)
 			return NULL;
 
 		next = (uint64_t)bp+size;
@@ -88,7 +88,7 @@ good:
 	}
 	else {
 		bp = sbrk(size);
-		if((intptr_t)bp == -1)
+		if((intptr_t)bp < 0)
 			return NULL;
 	}
 

--- a/lib/ap/plan9/mkdir.c
+++ b/lib/ap/plan9/mkdir.c
@@ -10,6 +10,7 @@
 #include "lib.h"
 #include <sys/stat.h>
 #include <errno.h>
+#include <unistd.h>
 #include "sys9.h"
 
 /*

--- a/lib/ap/plan9/rename.c
+++ b/lib/ap/plan9/rename.c
@@ -57,7 +57,7 @@ rename(const char *from, const char *to)
 		char buf[8192];
 
 		tfd = -1;
-		if((ffd = open(from, 0)) < 0 ||
+		if((ffd = __sys_open(from, 0)) < 0 ||
 		   (tfd = create(to, 1, d->mode)) < 0){
 			close(ffd);
 			_syserrno();

--- a/lib/ap/plan9/time.c
+++ b/lib/ap/plan9/time.c
@@ -24,7 +24,7 @@ time(time_t *tp)
 	time_t t;
 
 	memset(b, 0, sizeof(b));
-	f = open("/dev/time", 0);
+	f = __sys_open("/dev/time", 0);
 	if(f >= 0) {
 		pread(f, b, sizeof(b), 0);
 		close(f);

--- a/lib/ap/plan9/unlink.c
+++ b/lib/ap/plan9/unlink.c
@@ -60,7 +60,7 @@ unlink(const char *path)
 					}
 				}
 				/* reopen remove on close */
-				fd = open(p, 64|(f->oflags)); 
+				fd = __sys_open(p, 64|(f->oflags)); 
 				if(fd < 0){
 					free(db2);
 					continue;

--- a/lib/ap/stdio/__stdout_write.c
+++ b/lib/ap/stdio/__stdout_write.c
@@ -5,7 +5,7 @@ size_t __stdout_write(FILE *f, const unsigned char *buf, size_t len)
 {
 	//struct winsize wsz;
 	f->write = __stdio_write;
-	//if (!(f->flags & F_SVB) /*&& __syscall(SYS_ioctl, f->fd, TIOCGWINSZ, &wsz)*/)
-	//	f->lbf = -1;
+	if (!(f->flags & F_SVB) && ioctl(f->fd, FIONREAD, &f->buf_size))
+		f->lbf = -1;
 	return __stdio_write(f, buf, len);
 }

--- a/lib/ap/stdio/__towrite.c
+++ b/lib/ap/stdio/__towrite.c
@@ -5,6 +5,7 @@ int __towrite(FILE *f)
 	f->mode |= f->mode-1;
 	if (f->flags & (F_NOWR)) {
 		f->flags |= F_ERR;
+		write(2, "la\n", 3);
 		return EOF;
 	}
 	/* Clear read buffer (easier than summoning nasal demons) */
@@ -15,4 +16,11 @@ int __towrite(FILE *f)
 	f->wend = f->buf + f->buf_size;
 
 	return 0;
+}
+
+void __stdio_exit_needed(void);
+
+void __towrite_needs_stdio_exit()
+{
+	__stdio_exit_needed();
 }

--- a/lib/ap/stdio/fdopen.c
+++ b/lib/ap/stdio/fdopen.c
@@ -42,7 +42,7 @@ FILE *fdopen(int fd, const char *mode)
 
 	/* Activate line buffered mode for terminals */
 	f->lbf = EOF;
-	if (!(f->flags & F_NOWR) /*&& !__syscall(SYS_ioctl, fd, TIOCGWINSZ, &wsz)*/)
+	if (!(f->flags & F_NOWR) && !ioctl(fd, FIONREAD, &f->buf_size))
 		f->lbf = '\n';
 
 	/* Initialize op ptrs. No problem if some are unneeded. */

--- a/lib/ap/stdio/fwrite.c
+++ b/lib/ap/stdio/fwrite.c
@@ -17,7 +17,8 @@ size_t __fwritex(const unsigned char *restrict s, size_t l, FILE *restrict f)
 				return i;
 			s += i;
 			l -= i;
-		}
+		} else
+			f->write(f, s, i); /* BUG! for non '\n' terminated strings */
 	}
 
 	memcpy(f->wpos, s, l);


### PR DESCRIPTION
Returning to open syscall (__sys_open)
 for ap/plan9/* sources that originally were using it
 avoiding useless operations.
    
BUG: fixing non carrier return string in printf family (!!) (fwrite.c).
    
New writev from OpenBSD (improved).
    
Restoring original ioctl conditions from musl in:
 __stdout_write.c
 fdopen.c
 (improves control over stdout, though APEX only can use FIONREAD).
    
Restoring stdio_exit for __towrite (condition in fwrite).