### PR TITLE
Fixing _envsetup

### DIFF
--- a/lib/ap/plan9/_envsetup.c
+++ b/lib/ap/plan9/_envsetup.c
@@ -45,17 +45,17 @@ _envsetup(void)
 	char **pp;
 	char name[NAME_MAX+5];
 	Dir *d9, *d9a;
+	static char **emptyenvp = 0;
+
+	environ = emptyenvp;		/* pessimism */
 
 	nohandle = 0;
 	fdinited = 0;
 	cnt = 0;
 	strcpy(name, "#e");
 	dfd = __sys_open(name, 0);
-	if(dfd < 0){
-		environ = malloc(sizeof(char**));
-		*environ = NULL;
-		return;
-	}
+	if(dfd < 0)
+			return;
 	name[2] = '/';
 	ps = p = malloc(Envhunk);
 	if(p == 0)

--- a/lib/ap/plan9/malloc.c
+++ b/lib/ap/plan9/malloc.c
@@ -36,9 +36,9 @@ struct Arena
 };
 static Arena arena;
 
-#define datoff		((size_t)((Bucket*)0)->data)
+#define datoff		((int64_t)((Bucket*)0)->data)
 
-extern	void	*sbrk(uint32_t);
+extern	void	*sbrk(uint64_t);
 
 void*
 malloc(size_t size)


### PR DESCRIPTION
It was crashing at environ = NULL all the time.

First round of malloc. Bucket can't be unsigned long,
it must be signed and ssize_t produces an error.

Migrating to an sbrk with uint64_t arg. Native must be
moved too.

Change-Id: Ic8cbaf6f3f092839aea52fa3e34d4e353b28f87f