### PR TITLE
Fixing sleep syscall colliding

### DIFF
--- a/include/unistd.h
+++ b/include/unistd.h
@@ -101,7 +101,8 @@ extern int execvp(const char *, const char **);
 extern void _exit(int);
 extern unsigned int alarm(unsigned int);
 extern int pause(void);
-extern unsigned int sleep(unsigned int);
+extern unsigned int __sleep(unsigned int);
+#define sleep(u) __sleep(u);
 #ifdef __TYPES_H
 extern pid_t fork(void);
 #endif

--- a/lib/ap/bsd/pty.c
+++ b/lib/ap/bsd/pty.c
@@ -92,7 +92,7 @@ mkserver(void)
 				fd = open(fssrv, O_RDWR);
 				if(fd >= 0)
 					break;
-				sleep(1000);
+				__sys_sleep(1000);
 			}
 		}
 		if(fd < 0)

--- a/lib/ap/internal/sys9.h
+++ b/lib/ap/internal/sys9.h
@@ -126,6 +126,7 @@ extern	int	__sys_fstat(int, unsigned char*, int);
 extern	int	__sys_open(const char *, int);
 extern	int	__sys_pipe(int*);
 extern	int	__sys_remove(const char*);
+extern	int	__sys_sleep(int32_t);
 extern	int	__sys_stat(const char*, unsigned char*, int);
 
 /*

--- a/lib/ap/plan9/__sys_sleep.c
+++ b/lib/ap/plan9/__sys_sleep.c
@@ -7,21 +7,13 @@
  * in the LICENSE file.
  */
 
-#include <unistd.h>
-#define	NONEXIT	34
-void (*_atexitfns[NONEXIT])(void);
-void _doatexits(void){
-	int i;
-	void (*f)(void);
-	for(i = NONEXIT-1; i >= 0; i--)
-		if(_atexitfns[i]){
-			f = _atexitfns[i];
-			_atexitfns[i] = 0;	/* self defense against bozos */
-			(*f)();
-		}
-}
-void exit(int status)
+#include "sys9.h"
+
+/* syscall in libc */
+extern	int	sleep(int32_t);
+
+int
+__sys_sleep(int32_t i)
 {
-	_doatexits();
-	_exit(status);
+	return sleep(i);
 }

--- a/lib/ap/plan9/_buf.c
+++ b/lib/ap/plan9/_buf.c
@@ -286,7 +286,7 @@ select(int nfds, fd_set *rfds, fd_set *wfds, fd_set *efds, struct timeval *timeo
 			|| (efds && FD_ANYSET(efds)))) {
 		/* no requested fds */
 		if(t > 0)
-			sleep(t);
+			__sys_sleep(t);
 		return 0;
 	}
 
@@ -406,7 +406,7 @@ _timerproc(void)
 				__sys_close(i);
 		rendezvous(1, 0);
 		for(;;) {
-			sleep(mux->waittime);
+			__sys_sleep(mux->waittime);
 			if(timerreset) {
 				timerreset = 0;
 			} else {

--- a/lib/ap/plan9/_nap.c
+++ b/lib/ap/plan9/_nap.c
@@ -21,7 +21,7 @@ _nap(unsigned int millisecs)
 	time_t t0, t1;
 
 	t0 = time(0);
-	if(sleep(millisecs) < 0){
+	if(__sys_sleep(millisecs) < 0){
 		t1 = time(0);
 		return t1-t0;
 	}

--- a/lib/ap/plan9/pause.c
+++ b/lib/ap/plan9/pause.c
@@ -15,6 +15,6 @@ int
 pause(void)
 {
 	for(;;)
-		if(sleep(1000*1000) < 0)
+		if(__sys_sleep(1000*1000) < 0)
 			return -1;
 }

--- a/lib/ap/plan9/signal.c
+++ b/lib/ap/plan9/signal.c
@@ -120,7 +120,7 @@ _notehandler(void *u, char *msg)
 			noted(0); /* NCONT */
 		}
 	}
-	//_doatexits();
+	_doatexits();
 	noted(1); /* NDFLT */
 }
 

--- a/lib/ap/plan9/sleep.c
+++ b/lib/ap/plan9/sleep.c
@@ -13,12 +13,12 @@
 #include "sys9.h"
 
 unsigned int
-sleep(unsigned int secs)
+__sleep(unsigned int secs)
 {
 	time_t t0, t1;
 
 	t0 = time(0);
-	if(sleep(secs*1000) < 0){
+	if(__sys_sleep(secs*1000) < 0){
 		t1 = time(0);
 		return t1-t0;
 	}


### PR DESCRIPTION
-Added another wrapper for sleep syscall which was breaking
  wait, fork and pipe works.
-Returned doatexits in signal.c and exit.c, now that crt1.S
  exits properly in previous commit.
-Fixed sources what were using sleep syscall, now __sys_sleep.

--
-Still broken sigsetjmp, it's needed to fill _psigblocked to
  have sigprocmask working properly and some other signal functions.
-dup2 is broken too, just doesn't work. This will come in next PR,
  because with sleep (fixed) is breaking pex mess in gcc for calling
  subprocesses like as or ld.

Signed-off-by: Álvaro Jurado <elbingmiss@gmail.com>