### PR TITLE
Now that we have an official HarveyOS organization, we can have a more formal copyright policy.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ dirs:
 cmd: dirs
 	$(MAKE) -C cmd
 	$(MAKE) -C cmd install
+	$(MAKE) -C cmd clean
 
 lib: dirs
 	@cd lib && $(MAKE)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ dirs:
 	mkdir -p $(APEXLIB)
 	mkdir -p $(APEXBIN)
 
-cmd: dirs lib
+cmd: dirs
 	$(MAKE) -C cmd
 	$(MAKE) -C cmd install
 

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -1,50 +1,25 @@
 include $(APEX)/$(OS).inc
 
-DIRS=troff awk
+DIRS = troff awk sed
 BUILDDIRS=$(DIRS:%=build-%)
 INSTALLDIRS=$(DIRS:%=install-%)
 CLEANDIRS=$(DIRS:%=clean-%)
 
-EXPROBJ = expr.o
-UNAMEOBJ = uname.o
-KILLOBJ = kill.o
-BASENAMEOBJ = basename.o
-DIRNAMEOBJ = dirname.o
-
-%.o: %.c
-	$(CC) $(CFLAGS) -c $<
+PROGRAMS = expr uname kill basename dirname
 
 .PHONY: all clean
 
-all: $(DIRS) expr uname kill basename dirname clean
-
-%.o: %.c
-	$(CC) $(CFLAGS) -c $<
-
-clean: $(DIRS)
-	rm -f *.o expr uname kill basename dirname
-
-install: $(DIRS)
-	cp expr $(APEXBIN)
-	cp uname $(APEXBIN)
-	cp kill $(APEXBIN)
-	cp basename $(APEXBIN)
-	cp dirname $(APEXBIN)
+all: $(DIRS) $(PROGRAMS)
 
 $(DIRS):
 	$(MAKE) -C $@ $(MFLAGS) $(MAKECMDGOALS)
 
-expr: $(EXPROBJ)
-	$(LD) -static -nostdlib -o expr $(APEXLIB)/crt1.o $(APEXLIB)/crti.o $(APEXLIB)/crtn.o $(EXPROBJ) -L$(APEXLIB) -L$(HARVEYLIB) -lap -lc
+clean: $(DIRS)
 
-uname: $(UNAMEOBJ)
-	$(LD) -static -nostdlib -o uname $(APEXLIB)/crt1.o $(APEXLIB)/crti.o $(APEXLIB)/crtn.o $(UNAMEOBJ) -L$(APEXLIB) -L$(HARVEYLIB) -lap -lc
+install: $(DIRS)
 
-kill: $(KILLOBJ)
-	$(LD) -static -nostdlib -o kill $(APEXLIB)/crt1.o $(APEXLIB)/crti.o $(APEXLIB)/crtn.o $(KILLOBJ) -L$(APEXLIB) -L$(HARVEYLIB) -lap -lc
-
-basename: $(BASENAMEOBJ)
-	$(LD) -static -nostdlib -o basename $(APEXLIB)/crt1.o $(APEXLIB)/crti.o $(APEXLIB)/crtn.o $(BASENAMEOBJ) -L$(APEXLIB) -L$(HARVEYLIB) -lap -lc
-
-dirname: $(DIRNAMEOBJ)
-	$(LD) -static -nostdlib -o dirname $(APEXLIB)/crt1.o $(APEXLIB)/crti.o $(APEXLIB)/crtn.o $(DIRNAMEOBJ) -L$(APEXLIB) -L$(HARVEYLIB) -lap -lc
+$(PROGRAMS):
+	$(CC) $(CFLAGS) -c $@.c
+	$(LD) -static -nostdlib -o $@ $(APEXLIB)/crt1.o $(APEXLIB)/crti.o $(APEXLIB)/crtn.o $@.o -L$(APEXLIB) -L$(HARVEYLIB) -lap -lc
+	cp $@ $(APEXBIN)
+	rm -f $@.o $@

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -1,15 +1,35 @@
+include $(APEX)/$(OS).inc
+
 DIRS=troff awk
 BUILDDIRS=$(DIRS:%=build-%)
 INSTALLDIRS=$(DIRS:%=install-%)
 CLEANDIRS=$(DIRS:%=clean-%)
 
-.PHONY: $(DIRS)
+EXPROBJ = expr.o
+UNAMEOBJ = uname.o
 
-all: $(DIRS)
+%.o: %.c
+	$(CC) $(CFLAGS) -c $<
+
+.PHONY: all clean
+
+all: $(DIRS) expr uname clean
 
 clean: $(DIRS)
+	rm -f *.o expr uname
 
 install: $(DIRS)
+	cp expr $(APEXBIN)
+	cp uname $(APEXBIN)
 
 $(DIRS):
 	$(MAKE) -C $@ $(MFLAGS) $(MAKECMDGOALS)
+
+expr: $(EXPROBJ)
+	$(LD) -static -nostdlib -o expr $(APEXLIB)/crt1.o $(APEXLIB)/crti.o $(APEXLIB)/crtn.o $(EXPROBJ) -L$(APEXLIB) -L$(HARVEYLIB) -lap -lc
+
+uname: $(UNAMEOBJ)
+	$(LD) -static -nostdlib -o uname $(APEXLIB)/crt1.o $(APEXLIB)/crti.o $(APEXLIB)/crtn.o $(UNAMEOBJ) -L$(APEXLIB) -L$(HARVEYLIB) -lap -lc
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $<

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -1,13 +1,13 @@
 include $(APEX)/$(OS).inc
 
-DIRS = troff awk sed
+DIRS = troff awk sed pdksh
 BUILDDIRS=$(DIRS:%=build-%)
 INSTALLDIRS=$(DIRS:%=install-%)
 CLEANDIRS=$(DIRS:%=clean-%)
 
 PROGRAMS = expr uname kill basename dirname
 
-.PHONY: all clean
+.PHONY: $(DIRS) $(PROGRAMS)
 
 all: $(DIRS) $(PROGRAMS)
 

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -7,20 +7,29 @@ CLEANDIRS=$(DIRS:%=clean-%)
 
 EXPROBJ = expr.o
 UNAMEOBJ = uname.o
+KILLOBJ = kill.o
+BASENAMEOBJ = basename.o
+DIRNAMEOBJ = dirname.o
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $<
 
 .PHONY: all clean
 
-all: $(DIRS) expr uname clean
+all: $(DIRS) expr uname kill basename dirname clean
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $<
 
 clean: $(DIRS)
-	rm -f *.o expr uname
+	rm -f *.o expr uname kill basename dirname
 
 install: $(DIRS)
 	cp expr $(APEXBIN)
 	cp uname $(APEXBIN)
+	cp kill $(APEXBIN)
+	cp basename $(APEXBIN)
+	cp dirname $(APEXBIN)
 
 $(DIRS):
 	$(MAKE) -C $@ $(MFLAGS) $(MAKECMDGOALS)
@@ -31,5 +40,11 @@ expr: $(EXPROBJ)
 uname: $(UNAMEOBJ)
 	$(LD) -static -nostdlib -o uname $(APEXLIB)/crt1.o $(APEXLIB)/crti.o $(APEXLIB)/crtn.o $(UNAMEOBJ) -L$(APEXLIB) -L$(HARVEYLIB) -lap -lc
 
-%.o: %.c
-	$(CC) $(CFLAGS) -c $<
+kill: $(KILLOBJ)
+	$(LD) -static -nostdlib -o kill $(APEXLIB)/crt1.o $(APEXLIB)/crti.o $(APEXLIB)/crtn.o $(KILLOBJ) -L$(APEXLIB) -L$(HARVEYLIB) -lap -lc
+
+basename: $(BASENAMEOBJ)
+	$(LD) -static -nostdlib -o basename $(APEXLIB)/crt1.o $(APEXLIB)/crti.o $(APEXLIB)/crtn.o $(BASENAMEOBJ) -L$(APEXLIB) -L$(HARVEYLIB) -lap -lc
+
+dirname: $(DIRNAMEOBJ)
+	$(LD) -static -nostdlib -o dirname $(APEXLIB)/crt1.o $(APEXLIB)/crti.o $(APEXLIB)/crtn.o $(DIRNAMEOBJ) -L$(APEXLIB) -L$(HARVEYLIB) -lap -lc

--- a/cmd/README
+++ b/cmd/README
@@ -1,6 +1,6 @@
 This is an attempt to make the utilities specified in
-POSIX 1002.3 available, assuming /$objtype/ape/bin
-and /lib/rc/ape are bound to /bin before the regular
+POSIX 1002.3 available, assuming /apex/$objtype/bin
+and /apex/rc are bound to /bin before the regular
 bin directories.
 
 Here's a brief description of the status of these commands.

--- a/cmd/dirname.c
+++ b/cmd/dirname.c
@@ -11,10 +11,10 @@
 #include <string.h>
 #include <stdio.h>
 
+int
 main(int argc, char **argv)
 {
 	char *f, *s;
-	int n;
 
 	if(argc != 2){
 		fprintf(stderr, "Usage: dirname string\n");

--- a/cmd/kill.c
+++ b/cmd/kill.c
@@ -22,6 +22,7 @@ char *signm[NSIG+1] = { 0,
 "SIGSEGV", "SIGPIPE", "SIGALRM", "SIGTERM", "SIGUR1", "SIGUSR2", /* 8-13 */
 };
 
+int
 main(int argc, char **argv)
 {
 	int signo, pid, res;

--- a/cmd/pdksh/Makefile
+++ b/cmd/pdksh/Makefile
@@ -15,5 +15,8 @@ all: $(TARGET) clean
 $(TARGET): $(OBJ)
 	$(LD) -nostdlib -o $(TARGET) $(APEXLIB)/crt1.o $(APEXLIB)/crti.o $(APEXLIB)/crtn.o $(OBJ) -L$(APEXLIB) -L$(HARVEYLIB) -lap -lc
 
+install:
+	cp $(TARGET) $(APEXBIN)
+
 clean:
 	rm -f $(OBJ)

--- a/cmd/sed/Makefile
+++ b/cmd/sed/Makefile
@@ -1,0 +1,23 @@
+include $(APEX)/$(OS).inc
+
+TARGET = sed
+SRCS = $(wildcard *.c)
+OBJ = ${SRCS:.c=.o}
+
+CFLAGS += -I.
+
+.PHONY: all clean
+
+all: $(TARGET) clean
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $(SRCS)
+
+$(TARGET): $(OBJ)
+	$(LD) -static -nostdlib -o $(TARGET) $(APEXLIB)/crt1.o $(APEXLIB)/crti.o $(APEXLIB)/crtn.o $(OBJ) -L$(APEXLIB) -L$(HARVEYLIB) -lap -lc
+
+install:
+	cp $(TARGET) $(APEXBIN)
+
+clean:
+	rm -f $(OBJ)

--- a/lib/ap/bsd/basename.c
+++ b/lib/ap/bsd/basename.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/bsd/dirname.c
+++ b/lib/ap/bsd/dirname.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/bsd/getopt.c
+++ b/lib/ap/bsd/getopt.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/dirent/alphasort.c
+++ b/lib/ap/dirent/alphasort.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/dirent/dirfd.c
+++ b/lib/ap/dirent/dirfd.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/dirent/fdopendir.c
+++ b/lib/ap/dirent/fdopendir.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/dirent/readdir_r.c
+++ b/lib/ap/dirent/readdir_r.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/dirent/scandir.c
+++ b/lib/ap/dirent/scandir.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/dirent/seekdir.c
+++ b/lib/ap/dirent/seekdir.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/dirent/telldir.c
+++ b/lib/ap/dirent/telldir.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/dirent/versionsort.c
+++ b/lib/ap/dirent/versionsort.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/__ctype_b_loc.c
+++ b/lib/ap/gen/__ctype_b_loc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/__ctype_get_mb_cur_max.c
+++ b/lib/ap/gen/__ctype_get_mb_cur_max.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/__ctype_tolower_loc.c
+++ b/lib/ap/gen/__ctype_tolower_loc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/__ctype_toupper_loc.c
+++ b/lib/ap/gen/__ctype_toupper_loc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/isascii.c
+++ b/lib/ap/gen/isascii.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/isblank.c
+++ b/lib/ap/gen/isblank.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/iswalnum.c
+++ b/lib/ap/gen/iswalnum.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/iswalpha.c
+++ b/lib/ap/gen/iswalpha.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/iswblank.c
+++ b/lib/ap/gen/iswblank.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/iswcntrl.c
+++ b/lib/ap/gen/iswcntrl.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/iswctype.c
+++ b/lib/ap/gen/iswctype.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/iswdigit.c
+++ b/lib/ap/gen/iswdigit.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/iswgraph.c
+++ b/lib/ap/gen/iswgraph.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/iswlower.c
+++ b/lib/ap/gen/iswlower.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/iswprint.c
+++ b/lib/ap/gen/iswprint.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/iswpunct.c
+++ b/lib/ap/gen/iswpunct.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/iswspace.c
+++ b/lib/ap/gen/iswspace.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/iswupper.c
+++ b/lib/ap/gen/iswupper.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/iswxdigit.c
+++ b/lib/ap/gen/iswxdigit.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/toascii.c
+++ b/lib/ap/gen/toascii.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/towctrans.c
+++ b/lib/ap/gen/towctrans.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/wcswidth.c
+++ b/lib/ap/gen/wcswidth.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/wctrans.c
+++ b/lib/ap/gen/wctrans.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/gen/wcwidth.c
+++ b/lib/ap/gen/wcwidth.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/internal/floatscan.h
+++ b/lib/ap/internal/floatscan.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/internal/intscan.h
+++ b/lib/ap/internal/intscan.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/internal/libc.h
+++ b/lib/ap/internal/libc.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/internal/locale_impl.h
+++ b/lib/ap/internal/locale_impl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/internal/lookup.h
+++ b/lib/ap/internal/lookup.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/internal/shgetc.h
+++ b/lib/ap/internal/shgetc.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/internal/stdio_impl.h
+++ b/lib/ap/internal/stdio_impl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/locale/__lctrans.c
+++ b/lib/ap/locale/__lctrans.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/locale/__mo_lookup.c
+++ b/lib/ap/locale/__mo_lookup.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/locale/c_locale.c
+++ b/lib/ap/locale/c_locale.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/locale/dcngettext.c
+++ b/lib/ap/locale/dcngettext.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/locale/locale_map.c
+++ b/lib/ap/locale/locale_map.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/locale/localeconv.c
+++ b/lib/ap/locale/localeconv.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/locale/setlocale.c
+++ b/lib/ap/locale/setlocale.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/locale/wcscoll.c
+++ b/lib/ap/locale/wcscoll.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/locale/wcsxfrm.c
+++ b/lib/ap/locale/wcsxfrm.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/math/__fpclassifyl.c
+++ b/lib/ap/math/__fpclassifyl.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/math/__signbit.c
+++ b/lib/ap/math/__signbit.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/math/__signbitl.c
+++ b/lib/ap/math/__signbitl.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/math/copysignl.c
+++ b/lib/ap/math/copysignl.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/math/floatscan.c
+++ b/lib/ap/math/floatscan.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/math/fmodl.c
+++ b/lib/ap/math/fmodl.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/math/frexpl.c
+++ b/lib/ap/math/frexpl.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/math/scalbn.c
+++ b/lib/ap/math/scalbn.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/math/scalbnl.c
+++ b/lib/ap/math/scalbnl.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/multibyte/btowc.c
+++ b/lib/ap/multibyte/btowc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/multibyte/mbstowcs.c
+++ b/lib/ap/multibyte/mbstowcs.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/multibyte/wcstombs.c
+++ b/lib/ap/multibyte/wcstombs.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/multibyte/wctob.c
+++ b/lib/ap/multibyte/wctob.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/plan9/execl.c
+++ b/lib/ap/plan9/execl.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/plan9/execle.c
+++ b/lib/ap/plan9/execle.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/plan9/execlp.c
+++ b/lib/ap/plan9/execlp.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/regex/fnmatch.c
+++ b/lib/ap/regex/fnmatch.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/regex/glob.c
+++ b/lib/ap/regex/glob.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/regex/regerror.c
+++ b/lib/ap/regex/regerror.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/__fmodeflags.c
+++ b/lib/ap/stdio/__fmodeflags.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/__lockfile.c
+++ b/lib/ap/stdio/__lockfile.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/__overflow.c
+++ b/lib/ap/stdio/__overflow.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/__stdio_close.c
+++ b/lib/ap/stdio/__stdio_close.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/__stdio_exit.c
+++ b/lib/ap/stdio/__stdio_exit.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/__stdio_read.c
+++ b/lib/ap/stdio/__stdio_read.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/__stdio_seek.c
+++ b/lib/ap/stdio/__stdio_seek.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/__stdio_write.c
+++ b/lib/ap/stdio/__stdio_write.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/__stdout_write.c
+++ b/lib/ap/stdio/__stdout_write.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/__string_read.c
+++ b/lib/ap/stdio/__string_read.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/__toread.c
+++ b/lib/ap/stdio/__toread.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/__towrite.c
+++ b/lib/ap/stdio/__towrite.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/__uflow.c
+++ b/lib/ap/stdio/__uflow.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/_progname.c
+++ b/lib/ap/stdio/_progname.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/asprintf.c
+++ b/lib/ap/stdio/asprintf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/clearerr.c
+++ b/lib/ap/stdio/clearerr.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/ext.c
+++ b/lib/ap/stdio/ext.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/ext2.c
+++ b/lib/ap/stdio/ext2.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fclose.c
+++ b/lib/ap/stdio/fclose.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fdopen.c
+++ b/lib/ap/stdio/fdopen.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/feof.c
+++ b/lib/ap/stdio/feof.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/ferror.c
+++ b/lib/ap/stdio/ferror.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fflush.c
+++ b/lib/ap/stdio/fflush.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fgetc.c
+++ b/lib/ap/stdio/fgetc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fgetpos.c
+++ b/lib/ap/stdio/fgetpos.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fgets.c
+++ b/lib/ap/stdio/fgets.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fgetwc.c
+++ b/lib/ap/stdio/fgetwc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fgetws.c
+++ b/lib/ap/stdio/fgetws.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fileno.c
+++ b/lib/ap/stdio/fileno.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fopen.c
+++ b/lib/ap/stdio/fopen.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fprintf.c
+++ b/lib/ap/stdio/fprintf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fputc.c
+++ b/lib/ap/stdio/fputc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fputs.c
+++ b/lib/ap/stdio/fputs.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fputwc.c
+++ b/lib/ap/stdio/fputwc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fputws.c
+++ b/lib/ap/stdio/fputws.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fread.c
+++ b/lib/ap/stdio/fread.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/freopen.c
+++ b/lib/ap/stdio/freopen.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fscanf.c
+++ b/lib/ap/stdio/fscanf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fseek.c
+++ b/lib/ap/stdio/fseek.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fsetpos.c
+++ b/lib/ap/stdio/fsetpos.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/ftell.c
+++ b/lib/ap/stdio/ftell.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fwide.c
+++ b/lib/ap/stdio/fwide.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fwprintf.c
+++ b/lib/ap/stdio/fwprintf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fwrite.c
+++ b/lib/ap/stdio/fwrite.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/fwscanf.c
+++ b/lib/ap/stdio/fwscanf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/getc.c
+++ b/lib/ap/stdio/getc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/getc_unlocked.c
+++ b/lib/ap/stdio/getc_unlocked.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/getchar.c
+++ b/lib/ap/stdio/getchar.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/gets.c
+++ b/lib/ap/stdio/gets.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/getwc.c
+++ b/lib/ap/stdio/getwc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/getwchar.c
+++ b/lib/ap/stdio/getwchar.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/ofl.c
+++ b/lib/ap/stdio/ofl.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/ofl_add.c
+++ b/lib/ap/stdio/ofl_add.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/perror.c
+++ b/lib/ap/stdio/perror.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/printf.c
+++ b/lib/ap/stdio/printf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/putc.c
+++ b/lib/ap/stdio/putc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/putc_unlocked.c
+++ b/lib/ap/stdio/putc_unlocked.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/putchar.c
+++ b/lib/ap/stdio/putchar.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/puts.c
+++ b/lib/ap/stdio/puts.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/putwc.c
+++ b/lib/ap/stdio/putwc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/putwchar.c
+++ b/lib/ap/stdio/putwchar.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/rewind.c
+++ b/lib/ap/stdio/rewind.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/scanf.c
+++ b/lib/ap/stdio/scanf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/setbuf.c
+++ b/lib/ap/stdio/setbuf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/setvbuf.c
+++ b/lib/ap/stdio/setvbuf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/snprintf.c
+++ b/lib/ap/stdio/snprintf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/sprintf.c
+++ b/lib/ap/stdio/sprintf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/sscanf.c
+++ b/lib/ap/stdio/sscanf.c
@@ -1,7 +1,7 @@
 
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/stderr.c
+++ b/lib/ap/stdio/stderr.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/stdin.c
+++ b/lib/ap/stdio/stdin.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/stdout.c
+++ b/lib/ap/stdio/stdout.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/swprintf.c
+++ b/lib/ap/stdio/swprintf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/swscanf.c
+++ b/lib/ap/stdio/swscanf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/ungetc.c
+++ b/lib/ap/stdio/ungetc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/ungetwc.c
+++ b/lib/ap/stdio/ungetwc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/vasprintf.c
+++ b/lib/ap/stdio/vasprintf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/vfprintf.c
+++ b/lib/ap/stdio/vfprintf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/vfscanf.c
+++ b/lib/ap/stdio/vfscanf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/vfwprintf.c
+++ b/lib/ap/stdio/vfwprintf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/vfwscanf.c
+++ b/lib/ap/stdio/vfwscanf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/vprintf.c
+++ b/lib/ap/stdio/vprintf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/vscanf.c
+++ b/lib/ap/stdio/vscanf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/vsnprintf.c
+++ b/lib/ap/stdio/vsnprintf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/vsprintf.c
+++ b/lib/ap/stdio/vsprintf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/vsscanf.c
+++ b/lib/ap/stdio/vsscanf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/vswprintf.c
+++ b/lib/ap/stdio/vswprintf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/vswscanf.c
+++ b/lib/ap/stdio/vswscanf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/vwprintf.c
+++ b/lib/ap/stdio/vwprintf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/vwscanf.c
+++ b/lib/ap/stdio/vwscanf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/wcsftime.c
+++ b/lib/ap/stdio/wcsftime.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/wprintf.c
+++ b/lib/ap/stdio/wprintf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdio/wscanf.c
+++ b/lib/ap/stdio/wscanf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdlib/intscan.c
+++ b/lib/ap/stdlib/intscan.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdlib/shgetc.c
+++ b/lib/ap/stdlib/shgetc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdlib/wcstod.c
+++ b/lib/ap/stdlib/wcstod.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/stdlib/wcstol.c
+++ b/lib/ap/stdlib/wcstol.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/mempcpy.c
+++ b/lib/ap/string/mempcpy.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/strchrnul.c
+++ b/lib/ap/string/strchrnul.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/strdup.c
+++ b/lib/ap/string/strdup.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/strndup.c
+++ b/lib/ap/string/strndup.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/strnlen.c
+++ b/lib/ap/string/strnlen.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/strverscmp.c
+++ b/lib/ap/string/strverscmp.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wcscat.c
+++ b/lib/ap/string/wcscat.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wcschr.c
+++ b/lib/ap/string/wcschr.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wcscmp.c
+++ b/lib/ap/string/wcscmp.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wcscpy.c
+++ b/lib/ap/string/wcscpy.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wcscspn.c
+++ b/lib/ap/string/wcscspn.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wcslen.c
+++ b/lib/ap/string/wcslen.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wcsncat.c
+++ b/lib/ap/string/wcsncat.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wcsncmp.c
+++ b/lib/ap/string/wcsncmp.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wcsncpy.c
+++ b/lib/ap/string/wcsncpy.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wcspbrk.c
+++ b/lib/ap/string/wcspbrk.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wcsrchr.c
+++ b/lib/ap/string/wcsrchr.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wcsspn.c
+++ b/lib/ap/string/wcsspn.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wcsstr.c
+++ b/lib/ap/string/wcsstr.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wcstok.c
+++ b/lib/ap/string/wcstok.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wmemchr.c
+++ b/lib/ap/string/wmemchr.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wmemcmp.c
+++ b/lib/ap/string/wmemcmp.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wmemcpy.c
+++ b/lib/ap/string/wmemcpy.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wmemmove.c
+++ b/lib/ap/string/wmemmove.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.

--- a/lib/ap/string/wmemset.c
+++ b/lib/ap/string/wmemset.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2014 Rich Felker, et al.
- * Copyright (c) 2015-2016 Álvaro Jurado et al.
+ * Copyright (c) 2015-2016 HarveyOS et al.
  *
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE.mit file.


### PR DESCRIPTION
The policy from here on out is as follows:

we don't remove personal copyrights from imported code
when we create code, the copyright is HarveyOS
we don't add personal copyrights to code
if needed, when substantial changes are made, we'll add a HarveyOS copyright notice.
We expect this to be infrequent.
If we find other places where we have added personal copyrights since the
Harvey project began, we will remove them as well.

This policy accords with modern practice on projects such as Harvey.

Signed-off-by: Álvaro Jurado <elbingmiss@gmail.com>