### PR TITLE
add a panic function. Panic on sigsuspend, which is broken

### DIFF
--- a/lib/ap/plan9/panic.c
+++ b/lib/ap/plan9/panic.c
@@ -7,17 +7,10 @@
  * in the LICENSE file.
  */
 
-#include <signal.h>
-#include <errno.h>
+#include <stdio.h>
 
-/*
- * BUG: doesn't work
- */
-
-int
-sigsuspend(const sigset_t *c)
+void panic(char *s)
 {
-	panic("sigsuspend is not implemented");
-	errno = EINVAL;
-	return -1;
+	fprintf(stderr, "panic: %s\n", s);
+	exits(s);
 }


### PR DESCRIPTION
This at least diagnoses PART of the problems with pdksh, in that
it was spinning on unchanging memory variables and never bothering
to actually use a system call to see if the command had exited.
That's why it would "hang" on the command exiting. It was not
hanging. It was not ever checking.

It's a good idea, with unimplemented functions, to call panic.

If we had gdbserver we would probably have found this 6 months ago
at least.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>