### PR TITLE
Investing environ issue

### DIFF
--- a/include/limits.h
+++ b/include/limits.h
@@ -48,7 +48,7 @@
 #define FILESIZEBITS 64
 #define NAME_MAX 255
 #define SYMLINK_MAX 255
-#define PATH_MAX 4096
+//#define PATH_MAX 4096
 #define NZERO 20
 #define NGROUPS_MAX 32
 #define ARG_MAX 131072

--- a/include/limits.h
+++ b/include/limits.h
@@ -48,7 +48,6 @@
 #define FILESIZEBITS 64
 #define NAME_MAX 255
 #define SYMLINK_MAX 255
-//#define PATH_MAX 4096
 #define NZERO 20
 #define NGROUPS_MAX 32
 #define ARG_MAX 131072

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -90,7 +90,8 @@ extern "C" {
 #endif
 
 /* process primitives */
-extern int execl(const char *, const char * , ...);
+extern int _execl(const char *, const char * , ...);
+#define execl _execl
 extern int execv(const char *, char *const *);
 extern int execle(const char *, const char *,  ...);
 extern int execve(const char *, char *const *, char *const *);
@@ -103,7 +104,8 @@ extern int pause(void);
 extern unsigned int __sleep(unsigned int);
 #define sleep(u) __sleep(u)
 #ifdef __TYPES_H
-extern pid_t fork(void);
+extern pid_t _fork(void);
+#define fork _fork
 #endif
 
 /* process environment */

--- a/lib/ap/crt/crt1.S
+++ b/lib/ap/crt/crt1.S
@@ -6,10 +6,26 @@
 .globl	_start
 _start:
 
+	// 24 bytes room for environ
+	subq	$24, %rsp
+
+	// Prepare the environment
 	call	_envsetup
-	movq	0(%rsp), %rdi
-	leaq	8(%rsp), %rsi
-	movq	environ, %rbx
+	movq	%rax, 0(%rsp)
+	movq	environ, %rax
+	movq	%rax, 8(%rsp)
+
+	// argc, argv
+	movq	24(%rsp), %rdi
+	leaq	32(%rsp), %rsi
+
+
+	// Run constructors
+	call	_init
+
+	//  Give back 24 bytes of stack space
+	addq	$24, %rsp
+
 	call	main
 	movq	%rax, %rdi
 	call	exit

--- a/lib/ap/plan9/execl.c
+++ b/lib/ap/plan9/execl.c
@@ -11,7 +11,7 @@
 
 extern char **environ;
 
-int execl(const char *path, const char *argv0, ...)
+int _execl(const char *path, const char *argv0, ...)
 {
 	int argc;
 	va_list ap;

--- a/lib/ap/plan9/execle.c
+++ b/lib/ap/plan9/execle.c
@@ -21,7 +21,6 @@ int execle(const char *path, const char *argv0, ...)
 	{
 		int i;
 		char *argv[argc+1];
-		char **envp;
 		va_start(ap, argv0);
 		argv[0] = (char *)argv0;
 		for (i=1; i<=argc; i++)

--- a/lib/ap/plan9/fork.c
+++ b/lib/ap/plan9/fork.c
@@ -13,7 +13,7 @@
 #include "sys9.h"
 
 pid_t
-fork(void)
+_fork(void)
 {
 	int n;
 


### PR DESCRIPTION
Environ pointer is lost being called from make and possibly other programs.

- Avoiding collision with native fork and execl
- Fixing unistd.h and limits.h
- providing environ for execle.c
- _envsetup a la NIX and reworking of startup file crt1.S (needed renaming it to crt0.S).


Signed-off-by: Álvaro Jurado <elbingmiss@gmail.com>