### PR TITLE
Disabling stack protector at compile time

### DIFF
--- a/linux.inc
+++ b/linux.inc
@@ -15,7 +15,7 @@ LD=ld
 IDIR=${APEX}/include
 IOBJDIR=${APEX}/${ARCH}/include
 
-CFLAGS= -std=c11 -O2 -static -mno-red-zone -ffreestanding -nostdinc -nostdlib -D_SUSV2_SOURCE -D_POSIX_SOURCE -D_LIMITS_EXTENSION -DHARVEY ${WFLAGS} -g -I${IDIR} -I${IOBJDIR} -z noseparated-code -z max-page-size=0x200000
+CFLAGS= -std=c11 -O2 -static -mno-red-zone -ffreestanding -fno-stack-protector -nostdinc -nostdlib -D_SUSV2_SOURCE -D_POSIX_SOURCE -D_LIMITS_EXTENSION -DHARVEY ${WFLAGS} -g -I${IDIR} -I${IOBJDIR} -z noseparated-code -z max-page-size=0x200000
 
 WFLAGS=-Wall -Wno-missing-braces -Wno-parentheses -Wno-unknown-pragmas -Wuninitialized
 


### PR DESCRIPTION
For toolchains with this enabled by default

Signed-off-by: Álvaro Jurado <elbingmiss@gmail.com>